### PR TITLE
fix: externalize peer deps so the adapter tracks the installed better-auth

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,14 @@ import dts from "vite-plugin-dts"
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url))
 
+const external = [
+  /^better-auth(\/.*)?$/,
+  /^@better-auth\/[^/]+(\/.*)?$/,
+  /^@instantdb\/[^/]+(\/.*)?$/,
+  /^react(-dom)?(\/.*)?$/,
+  /^node:/
+]
+
 export default defineConfig({
   plugins: [
     dts({
@@ -18,7 +26,7 @@ export default defineConfig({
       fileName: "index"
     },
     rollupOptions: {
-      external: ["react", "react-dom", "node:util"]
+      external
     }
   },
   resolve: {


### PR DESCRIPTION
## Problem

We bumped `better-auth` to the latest version recently and found this issue during sign-in.

```
TypeError: txAdapter.consumeOne is not a function
    at consumeOneWithHooks (better-auth/dist/db/with-hooks.mjs:230:26)
    at withVerificationConsumeLock (better-auth/dist/db/internal-adapter.mjs:52:11)
    at Object.consumeVerificationValue (better-auth/dist/db/internal-adapter.mjs:714:17)
    at atomicVerifyOTP (better-auth/dist/plugins/email-otp/routes.mjs:759:19)
```

Upon our investigation, we found that `instantAdapter()` returns an adapter that is missing `consumeOne` and `incrementOne`. On `better-auth >= 1.6.22`, `consumeVerificationValue` consumes verification rows via `txAdapter.consumeOne(...)`.

## Root cause

`src/adapter/instant-adapter.ts` imports `createAdapterFactory` from `better-auth/adapters` correctly, but Vite library mode does **not** auto-externalize `dependencies`/`peerDependencies`, only what's listed in `build.rollupOptions.external`, which was `["react", "react-dom", "node:util"]`. 

Rollup therefore inlined the factory into `dist`, freezing the adapter surface at whatever better-auth version the package was *built* against (1.6.9), while types resolve against whatever the *consumer* installs. Methods added to the factory after 1.6.9 never reach consumers.

Evidence, holding the source constant and changing only `external`:

| | before | after |
|---|---|---|
| first line of `dist/index.js` | `const V = {` | `import { id as C } from "@instantdb/admin";` |
| occurrences of `better-auth` | 0 | 1 |
| size | 71,774 B | 10,704 B |

## Fix

Mark `better-auth`, `@better-auth/*` and `@instantdb/*` as external so the factory is resolved from the consumer's install at runtime. This fixes the whole class of bug rather than just `consumeOne`, future factory methods flow through automatically. It also stops shipping a duplicate copy of the `@instantdb/admin` peer.

## Verification

Loading the built adapter against better-auth 1.6.26 in an identical env:

| build | `consumeOne` | `incrementOne` |
|---|---|---|
| published 1.3.3 | `undefined` | `undefined` |
| this PR | `function` | `function` |

We've also packed and installed into our application for the verification and the sign in now succeeds with the verification row consumed via the factory's `findMany` + `deleteMany` fallback.